### PR TITLE
[fix] Revert changes from net6 to netstandard2.1

### DIFF
--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <NoWarn>CA1051, CA1815</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Net6 discontinued support for the library System.Drawing.Common

Therefor the project cannot be deployed in net6 yet.

Going to net6 requires someintegration work:
- integrating third party drawing library (SkiaSharp for example)
- fixing CA1051 in a couple of files